### PR TITLE
Show status on first time warning

### DIFF
--- a/app/controllers/game.js
+++ b/app/controllers/game.js
@@ -282,6 +282,7 @@ var Game = function Game(channel, client, config) {
         } else if (roundElapsed >= timeLimit - (60 * 1000) && roundElapsed < timeLimit - (50 * 1000)) {
             // 60s ... 50s left
             self.say('Hurry up, 1 minute left!');
+            self.showStatus();
         }
     };
 


### PR DESCRIPTION
It's helpful to know who still needs to play when the first time warning appears, and it seems somebody always issues the !status command at that point.
