### PR TITLE
Implement topic set feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Card configuration is located in `config/cards` directory. There are 2 files by 
 
 Black cards are what players draw from the deck to their hands, white cards are the "question cards". Yes, this is the opposite of the original Cards Against Humanity. No, it wasn't done intentionally, but that's the way it is now. 
 
+###Set Topic
+The bot can be configured to set the channel topic indicating whether a game is running or not by setting the `setTopic` directive to true. The `topicBase` directive will be appended to the end of the status information. The bot must have permission in the channel for this to work.
+
 ##TODO
 * Save game & player data to MongoDB for all time top scores & other statistics.
 * Allow pausing/resuming a game.

--- a/app/controllers/game.js
+++ b/app/controllers/game.js
@@ -86,6 +86,9 @@ var Game = function Game(channel, client, config) {
         delete self.decks;
         delete self.discards;
         delete self.table;
+
+        // set topic
+        self.setTopic(c.bold.yellow('No game is running. Type !start to begin one!'));
     };
 
     /**
@@ -589,6 +592,26 @@ var Game = function Game(channel, client, config) {
     };
 
     /**
+     * Set the channel topic
+     */
+    self.setTopic = function(topic) {
+        // ignore if not configured to set topic
+        if (typeof config.setTopic === 'undefined' || !config.setTopic) {
+            return false;
+        }
+
+        // construct new topic
+        if (typeof config.topicBase === 'undefined') {
+            var newTopic = topic;
+        } else {
+            var newTopic = topic + ' ' + config.topicBase;
+        }
+
+        // set it
+        client.send('TOPIC', channel, newTopic);
+    };
+
+    /**
      * List all players in the current game
      */
     self.listPlayers = function () {
@@ -640,6 +663,9 @@ var Game = function Game(channel, client, config) {
     self.notice = function (nick, string) {
         self.client.notice(nick, string);
     };
+
+    // set topic
+    self.setTopic(c.bold.lime('A game is running. Type !join to get in on it!'));
 
     // announce the game on the channel
     self.say('A new game of ' + c.rainbow('Cards Against Humanity') + '. The game starts in 30 seconds. Type !join to join the game any time.');

--- a/config/env/development.json
+++ b/config/env/development.json
@@ -1,6 +1,8 @@
 {
     "server":        "irc.saunalahti.fi",
     "nick":          "cah-dev",
+    "setTopic":      true,
+    "topicBase":     "|| This will be appended to the topic along with the game status.",
     "clientOptions": {
         "userName":             "cah",
         "debug":                true,

--- a/config/env/production.json
+++ b/config/env/production.json
@@ -1,6 +1,8 @@
 {
     "server":        "openirc.snt.utwente.nl",
     "nick":          "cah",
+    "setTopic":      true,
+    "topicBase":     "|| This will be appended to the topic along with the game status.",
     "clientOptions": {
         "userName":             "cah",
         "channels":             ["#cah"],


### PR DESCRIPTION
Enables the bot to set the channel topic with status information so that new users entering the channel know they should either !join the currently running game or !start a new one. Can be enabled/disabled in the configuration as well as an optional "topic base" set to be appended at the end of the topic.
